### PR TITLE
Rename record map helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.log
 build
 db
+tmp

--- a/src/client/RecordLoader.ts
+++ b/src/client/RecordLoader.ts
@@ -1,4 +1,4 @@
-import { deleteRecordMap, getRecordMap, setRecordMap } from "../shared/recordMapHelpers"
+import { RecordMapHelpers } from "../shared/recordMapHelpers"
 import { RecordPointer, RecordTable } from "../shared/schema"
 
 class Loader<T> extends Promise<T> {
@@ -35,16 +35,16 @@ export class RecordLoader {
 	private loaderMap: { [table: string]: { [id: string]: Loader<void> } } = {}
 
 	unloadRecord(pointer: RecordPointer) {
-		deleteRecordMap(this.loaderMap, pointer)
+		RecordMapHelpers.deleteRecord(this.loaderMap, pointer)
 	}
 
 	loadRecord<T extends RecordTable>(pointer: RecordPointer<T>) {
-		const loader = getRecordMap(this.loaderMap, pointer)
+		const loader = RecordMapHelpers.getRecord(this.loaderMap, pointer)
 		if (loader) return loader
 		// if (loader && !loader.error) return loader
 
 		const newLoader = Loader.wrap(this.args.onFetchRecord(pointer))
-		setRecordMap(this.loaderMap, pointer, newLoader)
+		RecordMapHelpers.setRecord(this.loaderMap, pointer, newLoader)
 		return newLoader
 	}
 }

--- a/src/client/TransactionQueue.ts
+++ b/src/client/TransactionQueue.ts
@@ -2,7 +2,7 @@ import { isEqual, uniqWith } from "lodash"
 import { SecondMs } from "../shared/dateHelpers"
 import { DeferredPromise } from "../shared/DeferredPromise"
 import { BrokenError, TransactionConflictError, ValidationError } from "../shared/errors"
-import { setRecordMap } from "../shared/recordMapHelpers"
+import { RecordMapHelpers } from "../shared/recordMapHelpers"
 import { RecordMap, RecordPointer } from "../shared/schema"
 import { sleep } from "../shared/sleep"
 import { applyOperation, Transaction } from "../shared/transaction"
@@ -29,7 +29,7 @@ export class TransactionQueue {
 		const recordMap: RecordMap = {}
 		for (const pointer of pointers) {
 			const record = this.environment.cache.getRecord(pointer)
-			setRecordMap(recordMap, pointer, record)
+			RecordMapHelpers.setRecord(recordMap, pointer, record)
 		}
 
 		// Apply the mutations.

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import ReactDOM from "react-dom"
 import { DeferredPromise } from "../shared/DeferredPromise"
-import { setRecordMap } from "../shared/recordMapHelpers"
+import { RecordMapHelpers } from "../shared/recordMapHelpers"
 import { RecordMap } from "../shared/schema"
 import { createClientApi } from "./api"
 import { App } from "./App"
@@ -57,7 +57,7 @@ const loader = new RecordLoader({
 		const cached = storage.getRecord(pointer).then((record) => {
 			if (!record) return
 			const recordMap: RecordMap = {}
-			setRecordMap(recordMap, pointer, record)
+			RecordMapHelpers.setRecord(recordMap, pointer, record)
 			cache.updateRecordMap(recordMap)
 			deferred.resolve()
 			return record

--- a/src/server/JsonDatabase.ts
+++ b/src/server/JsonDatabase.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs-extra"
 import { TransactionConflictError } from "../shared/errors"
-import { getRecordMap, setRecordMap } from "../shared/recordMapHelpers"
+import { RecordMapHelpers } from "../shared/recordMapHelpers"
 import {
 	RecordMap,
 	RecordPointer,
@@ -29,7 +29,7 @@ export class JsonDatabase implements DatabaseApi {
 	async getRecord<T extends RecordTable>(
 		pointer: RecordPointer<T>
 	): Promise<TableToRecord[T] | undefined> {
-		const record = getRecordMap(this.data, pointer)
+		const record = RecordMapHelpers.getRecord(this.data, pointer)
 		// @ts-ignore
 		return record
 	}
@@ -37,8 +37,8 @@ export class JsonDatabase implements DatabaseApi {
 	async getRecords(pointers: RecordPointer[]): Promise<RecordMap> {
 		const recordMap: RecordMap = {}
 		for (const pointer of pointers) {
-			const record = getRecordMap(this.data, pointer)
-			if (record) setRecordMap(recordMap, pointer, record)
+			const record = RecordMapHelpers.getRecord(this.data, pointer)
+			if (record) RecordMapHelpers.setRecord(recordMap, pointer, record)
 		}
 		return recordMap
 	}
@@ -83,7 +83,7 @@ export class JsonDatabase implements DatabaseApi {
 		// First, lets assert that the previous version lines up transactionally.
 		for (const { table, id, record } of records) {
 			const pointer = { table, id } as RecordPointer
-			const current = getRecordMap(this.data, pointer) as RecordValue | undefined
+			const current = RecordMapHelpers.getRecord(this.data, pointer) as RecordValue | undefined
 
 			if (current && current.version !== record.last_version) throw new TransactionConflictError()
 		}
@@ -91,7 +91,7 @@ export class JsonDatabase implements DatabaseApi {
 		// No transaction conflict so lets update.
 		for (const { table, id, record } of records) {
 			const pointer = { table, id } as RecordPointer
-			setRecordMap(this.data, pointer, record)
+			RecordMapHelpers.setRecord(this.data, pointer, record)
 		}
 
 		// Write the file.

--- a/src/server/apis/login.ts
+++ b/src/server/apis/login.ts
@@ -3,7 +3,7 @@ import * as t from "data-type-ts"
 import type { Request, Response } from "express"
 import { DayMs } from "../../shared/dateHelpers"
 import { BrokenError, ValidationError } from "../../shared/errors"
-import { setRecordMap } from "../../shared/recordMapHelpers"
+import { RecordMapHelpers } from "../../shared/recordMapHelpers"
 import { AuthTokenRecord, RecordMap } from "../../shared/schema"
 import { op, Operation } from "../../shared/transaction"
 import type { ApiEndpoint } from "../api"
@@ -101,7 +101,7 @@ export async function login(
 	await write(environment, { authorId: config.adminUserId, operations })
 
 	const recordMap: RecordMap = {}
-	setRecordMap(recordMap, { table: "user", id: user.id }, user)
+	RecordMapHelpers.setRecord(recordMap, { table: "user", id: user.id }, user)
 	return { recordMap }
 }
 

--- a/src/server/apis/searchUsers.ts
+++ b/src/server/apis/searchUsers.ts
@@ -1,5 +1,5 @@
 import * as t from "data-type-ts"
-import { setRecordMap } from "../../shared/recordMapHelpers"
+import { RecordMapHelpers } from "../../shared/recordMapHelpers"
 import type { RecordMap } from "../../shared/schema"
 import type { ApiEndpoint } from "../api"
 import type { ServerEnvironment } from "../ServerEnvironment"
@@ -16,7 +16,7 @@ export async function searchUsers(environment: ServerEnvironment, args: typeof i
 
 	const recordMap: RecordMap = {}
 	for (const user of users) {
-		setRecordMap(recordMap, { table: "user", id: user.id }, user)
+		RecordMapHelpers.setRecord(recordMap, { table: "user", id: user.id }, user)
 	}
 	const userIds = users.map((user) => user.id)
 

--- a/src/server/apis/write.ts
+++ b/src/server/apis/write.ts
@@ -1,6 +1,6 @@
 import * as t from "data-type-ts"
 import { cloneDeep, difference, isEqual, uniqWith } from "lodash"
-import { getRecordMap } from "../../shared/recordMapHelpers"
+import { RecordMapHelpers } from "../../shared/recordMapHelpers"
 import type { RecordPointer, RecordWithTable, ThreadRecord } from "../../shared/schema"
 import { applyOperation, Operation, Transaction } from "../../shared/transaction"
 import type { ApiEndpoint } from "../api"
@@ -27,7 +27,7 @@ export async function write(environment: ServerEnvironment, args: typeof input.v
 
 	// Keep track of the previous version so we can assert on write.
 	for (const pointer of pointers) {
-		const record: any = getRecordMap(recordMap, pointer)
+		const record = RecordMapHelpers.getRecord(recordMap, pointer)
 		if (record) record.last_version = record.version
 	}
 
@@ -43,7 +43,7 @@ export async function write(environment: ServerEnvironment, args: typeof input.v
 	const records = pointers.map((pointer) => {
 		const record: RecordWithTable = {
 			...pointer,
-			record: getRecordMap(recordMap, pointer) as any,
+			record: RecordMapHelpers.getRecord(recordMap, pointer) as any,
 		}
 		return record
 	})
@@ -71,8 +71,8 @@ export async function write(environment: ServerEnvironment, args: typeof input.v
 
 		for (const pointer of pointers) {
 			if (pointer.table !== "thread") continue
-			const prev = getRecordMap(originalRecordMap, pointer) as ThreadRecord | undefined
-			const next = getRecordMap(recordMap, pointer) as ThreadRecord | undefined
+			const prev = RecordMapHelpers.getRecord(originalRecordMap, pointer)
+			const next = RecordMapHelpers.getRecord(recordMap, pointer)
 
 			const prevMembers = prev ? prev.member_ids || [] : []
 			const nextMembers = next ? next.member_ids || [] : []

--- a/src/shared/recordMapHelpers.ts
+++ b/src/shared/recordMapHelpers.ts
@@ -1,50 +1,46 @@
+import { set } from "lodash"
 import { RecordWithTable } from "./schema"
 
-// TODO: these types aren't perfect.
-export function getRecordMap<
-	R extends { [table: string]: { [id: string]: any } },
-	T extends keyof R
->(recordMap: R, pointer: { table: T; id: string }): R[T][string] | undefined {
-	const { table, id } = pointer
-	if (!recordMap[table]) return
-	return recordMap[table][id]
-}
+export namespace RecordMapHelpers {
+	export function getRecord<
+		R extends { [table: string]: { [id: string]: any } },
+		T extends keyof R
+	>(recordMap: R, pointer: { table: T; id: string }): NonNullable<R[T]>[string] | undefined {
+		const { table, id } = pointer
+		return recordMap[table]?.[id]
+	}
 
-// TODO: these types aren't perfect.
-// NOTE: this function mutates the recordMap!
-export function setRecordMap<
-	R extends { [table: string]: { [id: string]: any } },
-	T extends keyof R
->(recordMap: R, pointer: { table: T; id: string }, value: R[T][string]) {
-	const { table, id } = pointer
+	/** NOTE: this function mutates the recordMap! */
+	export function setRecord<
+		R extends { [table: string]: { [id: string]: any } },
+		T extends keyof R
+	>(recordMap: R, pointer: { table: T; id: string }, value: NonNullable<R[T]>[string]) {
+		const { table, id } = pointer
+		set(recordMap, [table, id], value)
+	}
 
-	// @ts-ignore
-	if (!recordMap[table]) recordMap[table] = {}
-	// @ts-ignore
-	recordMap[table][id] = value
-}
+	/** NOTE: this function mutates the recordMap! */
+	export function deleteRecord<
+		R extends { [table: string]: { [id: string]: any } },
+		T extends keyof R
+	>(recordMap: R, pointer: { table: T; id: string }) {
+		const { table, id } = pointer
 
-// NOTE: this function mutates the recordMap!
-export function deleteRecordMap<
-	R extends { [table: string]: { [id: string]: any } },
-	T extends keyof R
->(recordMap: R, pointer: { table: T; id: string }) {
-	const { table, id } = pointer
-
-	if (recordMap[table]) {
-		delete recordMap[table][id]
-		if (Object.keys(recordMap[table]).length === 0) {
-			delete recordMap[table]
+		if (recordMap[table]) {
+			delete recordMap[table][id]
+			if (Object.keys(recordMap[table]).length === 0) {
+				delete recordMap[table]
+			}
 		}
 	}
-}
 
-export function* iterateRecordMap<
-	R extends { [table: string]: { [id: string]: any } }
->(recordMap: R): Generator<RecordWithTable> {
-	for (const [table, idMap] of Object.entries(recordMap)) {
-		for (const [id, record] of Object.entries(idMap)) {
-			yield { table, id, record } as RecordWithTable
+	export function* iterateRecordMap<R extends { [table: string]: { [id: string]: any } }>(
+		recordMap: R
+	): Generator<RecordWithTable> {
+		for (const [table, idMap] of Object.entries(recordMap)) {
+			for (const [id, record] of Object.entries(idMap)) {
+				yield { table, id, record } as RecordWithTable
+			}
 		}
 	}
 }

--- a/src/shared/transaction.ts
+++ b/src/shared/transaction.ts
@@ -1,6 +1,6 @@
 import { cloneDeep, isEqual, set, update } from "lodash"
 import { ValidationError } from "./errors"
-import { getRecordMap, setRecordMap } from "./recordMapHelpers"
+import { RecordMapHelpers } from "./recordMapHelpers"
 import { RecordMap, RecordPointer, RecordTable, TableToRecord } from "./schema"
 
 export type SetOperation = {
@@ -78,27 +78,27 @@ function applySetOperation(recordMap: RecordMap, operation: SetOperation) {
 	const { table, id } = operation
 	const pointer = { table, id } as RecordPointer
 
-	const record: any = getRecordMap(recordMap, pointer)
+	const record: any = RecordMapHelpers.getRecord(recordMap, pointer)
 
 	if (!record) {
 		if (operation.key.length !== 0) throw new ValidationError("Record does not exist.")
 
 		const record = { ...operation.value, version: 1 }
-		setRecordMap(recordMap, pointer, record)
+		RecordMapHelpers.setRecord(recordMap, pointer, record)
 		return
 	}
 
 	const newRecord = cloneDeep(record)
 	set(newRecord, operation.key, operation.value)
 	newRecord.version += 1
-	setRecordMap(recordMap, pointer, newRecord)
+	RecordMapHelpers.setRecord(recordMap, pointer, newRecord)
 }
 
 function applyListInsertOperation(recordMap: RecordMap, operation: ListInsertOperation) {
 	const { table, id, value, where } = operation
 	const pointer = { table, id } as RecordPointer
 
-	const record: any = getRecordMap(recordMap, pointer)
+	const record = RecordMapHelpers.getRecord(recordMap, pointer)
 	if (!record) throw new ValidationError("Record does not exist.")
 
 	const newRecord = cloneDeep(record)
@@ -130,7 +130,7 @@ function applyListInsertOperation(recordMap: RecordMap, operation: ListInsertOpe
 		throw new ValidationError("Cannot insert on a non-list.")
 	})
 	newRecord.version += 1
-	setRecordMap(recordMap, pointer, newRecord)
+	RecordMapHelpers.setRecord(recordMap, pointer, newRecord)
 }
 
 function indexOf<T>(list: T[], value: T) {
@@ -144,7 +144,7 @@ function applyListRemoveOperation(recordMap: RecordMap, operation: ListRemoveOpe
 	const { table, id, value } = operation
 	const pointer = { table, id } as RecordPointer
 
-	const record: any = getRecordMap(recordMap, pointer)
+	const record = RecordMapHelpers.getRecord(recordMap, pointer)
 	if (!record) throw new ValidationError("Record does not exist.")
 
 	const newRecord = cloneDeep(record)
@@ -158,5 +158,5 @@ function applyListRemoveOperation(recordMap: RecordMap, operation: ListRemoveOpe
 		throw new ValidationError("Cannot remove from a non-list.")
 	})
 	newRecord.version += 1
-	setRecordMap(recordMap, pointer, newRecord)
+	RecordMapHelpers.setRecord(recordMap, pointer, newRecord)
 }


### PR DESCRIPTION
Not sure how you'll feel about this, but this PR renames:

- `getRecordMap` renamed to `getRecord` because it returns a record not a record map.
- `setRecordMap` renamed to `setRecord` because it sets a record on the RecordMap, rather than setting a RecordMap. 
- `deleteRecordMap` renamed to `deleteRecord` because it just deletes a single record.