### PR TITLE
Fix: RecordPointer type signature

### DIFF
--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -88,9 +88,7 @@ export type RecordWithTable<Table extends RecordTable = RecordTable> = {
 	[T in RecordTable]: { table: T; id: string; record: TableToRecord[T] }
 }[Table]
 
-export type RecordPointer<Table extends RecordTable = RecordTable> = {
-	[T in RecordTable]: { table: T; id: string }
-}[Table]
+export type RecordPointer<Table extends RecordTable = RecordTable> = { table: Table; id: string }
 
 export type RecordMap = {
 	[T in RecordTable]?: {


### PR DESCRIPTION
This refactors the RecordPointer type signature to use an interface instead of a discriminated union type because typescript's type inference is improved with the interface version of the type.

https://www.loom.com/share/086feabe2622407c9e95a31aee50e020