### PR TITLE
Improve pointerToKey typing

### DIFF
--- a/src/client/RecordCache.ts
+++ b/src/client/RecordCache.ts
@@ -26,9 +26,11 @@ export type RecordCacheApi = {
 }
 
 export function pointerToKey<T extends RecordTable>({ table, id }: RecordPointer<T>) {
-	return [table, id].join(":")
+	return [table, id].join(":") as `${T}:${string}`
 }
 
+export function keyToPointer<T extends RecordTable>(key: `${T}:${string}`): RecordPointer<T>
+export function keyToPointer(key: string): RecordPointer
 export function keyToPointer(key: string) {
 	const [table, id] = key.split(":")
 	return { table, id } as RecordPointer


### PR DESCRIPTION
Small improvement to the typing of `pointerToKey()` and `keyToPointer()`. I've never actually had a usecase for template literal types before! Seems to work well :)